### PR TITLE
Added support to execute build.py on local environment

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,27 +1,43 @@
 from conan.packager import ConanMultiPackager, os, re
 
-    
-if __name__ == "__main__":
+
+def get_name_version_from_recipe():
+    with open("conanfile.py", "r") as conanfile:
+        contents = conanfile.read()
+        name = re.search(r'name\s*=\s*"(\S*)"', contents).groups()[0]
+        version = re.search(r'version\s*=\s*"(\S*)"', contents).groups()[0]
+    return name, version
+
+def get_default_vars():
+    username = os.getenv("CONAN_USERNAME", "bincrafters")
+    channel = os.getenv("CONAN_CHANNEL", "testing")
+    _, version = get_name_version_from_recipe()
+    return username, channel, version
+
+def is_ci_running():
+    return os.getenv("APPVEYOR_REPO_NAME","") or os.getenv("TRAVIS_REPO_SLUG","")
+
+def get_ci_vars():
     reponame_a = os.getenv("APPVEYOR_REPO_NAME","")
     repobranch_a = os.getenv("APPVEYOR_REPO_BRANCH","")
 
     reponame_t = os.getenv("TRAVIS_REPO_SLUG","")
     repobranch_t = os.getenv("TRAVIS_BRANCH","")
-    if reponame_t or reponame_a:
-        username, repo = reponame_a.split("/") if reponame_a else reponame_t.split("/")
-        channel, version = repobranch_a.split("/") if repobranch_a else repobranch_t.split("/")
-        
-        with open("conanfile.py", "r") as conanfile:
-            contents = conanfile.read()
-            name = re.search(r'name\s*=\s*"(\S*)"', contents).groups()[0]
-            version = re.search(r'version\s*=\s*"(\S*)"', contents).groups()[0]
-        
-        os.environ["CONAN_USERNAME"] = username
-        os.environ["CONAN_CHANNEL"] = channel
-        os.environ["CONAN_REFERENCE"] = "{0}/{1}".format(name, version)
-        os.environ["CONAN_UPLOAD"]="https://api.bintray.com/conan/{0}/public-conan".format(username)
-        os.environ["CONAN_REMOTES"]="https://api.bintray.com/conan/{0}/public-conan".format(username)
 
-    builder = ConanMultiPackager()
-    builder.add_common_builds()    
+    username, _ = reponame_a.split("/") if reponame_a else reponame_t.split("/")
+    channel, version = repobranch_a.split("/") if repobranch_a else repobranch_t.split("/")
+    return username, channel, version
+
+def get_env_vars():
+    return get_ci_vars() if is_ci_running() else get_default_vars()
+
+if __name__ == "__main__":
+    name, _ = get_name_version_from_recipe()
+    username, channel, version = get_env_vars()
+    reference = "{0}/{1}".format(name, version)
+    upload = "https://api.bintray.com/conan/{0}/public-conan".format(username)
+
+    builder = ConanMultiPackager(username=username, channel=channel, reference=reference, upload=upload,
+                                 upload_only_when_stable=True, stable_branch_pattern="stable/*")
+    builder.add_common_builds(shared_option_name="%s:shared" % name)
     builder.run()


### PR DESCRIPTION
Hi!

The configuration in build.py allow to create the package avoiding to copy all settings for each CI environment.

However, when I want to build in a local container, this script is not useful for me. Would be nice if we have the opportunity to build in both cases by the same script.

This PR brings a new conditional, when the environment is not CI, then it uses `CONAN_USERNAME` and `CONAN_CHANNEL` to fill the username and the channel. Otherwise, it uses *bincrafters* and *testing*, respectively.

Regards.