### PR TITLE
Remove bad smells from CMake

### DIFF
--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,13 +1,8 @@
 project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-file(GLOB SOURCE_FILES *.cpp)
-
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,6 +1,8 @@
-// #include <cpprest/json.h>
+#include <cstdlib>
+#include <iostream>
 
 int main()
 {
-    // const auto parsed_value = web::json::value::parse(U("-22"));
+    std::cout << "Bincrafters\n";
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I'm just following some recommendations that I learned during CppNow and CppCon.

Both Daniel Pfeifer and Mathieu Ropert pointed some bad practices using CMake. 