### PR TITLE
Added info about centralized issue page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Note: It is recommended that you run conan install from a build directory and no
 
 The example below shows the commands used to publish to bincrafters conan repository. To publish to your own conan respository (for example, after forking this git repository), you will need to change the commands below accordingly.
 
+## Issues
+
+All issues, such as feature request, bug, support or discussion are centralized on Community repository. If you are interested to open a new issue, please visit https://github.com/bincrafters/community/issues.
+
 ## Build and package
 
 The following command both runs all the steps of the conan file, and publishes the package to the local system cache.  This includes downloading dependencies from "build_requires" and "requires" , and then running the build() method.


### PR DESCRIPTION
There is not way to know where an issue should be created after we moved all to community/issues.

Indeed, on Bintray page there is some info, but the user needs to search on Bintray and all metadata are filled manually ...

This PR just point our community repo as a central point to create any issue.