### PR TITLE
Make it usable for building outside of bincrafters

### DIFF
--- a/build.py
+++ b/build.py
@@ -58,6 +58,9 @@ if __name__ == "__main__":
     username, channel, version = get_env_vars()
     reference = "{0}/{1}".format(name, version)
     upload = "https://api.bintray.com/conan/{0}/public-conan".format(username)
+    upload_only_when_stable = True
+    if os.getenv('CONAN_UPLOAD_ONLY_WHEN_STABLE', '1') != '1':
+        upload_only_when_stable = False
 
     build = os.getenv("BUILD", None)
     if build:
@@ -72,7 +75,10 @@ if __name__ == "__main__":
         channel=os.getenv("CONAN_CHANNEL", channel),
         reference=os.getenv("CONAN_REFERENCE", reference),
         upload=os.getenv("CONAN_UPLOAD", upload),
-        remotes=os.getenv("CONAN_REMOTES", upload))
+        remotes=os.getenv("CONAN_REMOTES", upload),
+        upload_only_when_stable=upload_only_when_stable,
+        stable_branch_pattern=os.getenv("CONAN_STABLE_BRANCH_PATTERN", 'stable/*'))
 
-    builder.add_common_builds(shared_option_name="*:shared")
+    builder.add_common_builds(
+        shared_option_name=os.getenv('CONAN_SHARED_OPTION_NAME', name + ":shared"))
     builder.run()

--- a/build.py
+++ b/build.py
@@ -34,11 +34,11 @@ def is_ci_running():
 
 
 def get_ci_vars():
-    reponame_a = os.getenv("APPVEYOR_REPO_NAME","")
-    repobranch_a = os.getenv("APPVEYOR_REPO_BRANCH","")
+    reponame_a = os.getenv("APPVEYOR_REPO_NAME", "")
+    repobranch_a = os.getenv("APPVEYOR_REPO_BRANCH", "")
 
-    reponame_t = os.getenv("TRAVIS_REPO_SLUG","")
-    repobranch_t = os.getenv("TRAVIS_BRANCH","")
+    reponame_t = os.getenv("TRAVIS_REPO_SLUG", "")
+    repobranch_t = os.getenv("TRAVIS_BRANCH", "")
 
     username, _ = reponame_a.split("/") if reponame_a else reponame_t.split("/")
     channel, version = repobranch_a.split("/") if repobranch_a else repobranch_t.split("/")
@@ -59,14 +59,20 @@ if __name__ == "__main__":
     reference = "{0}/{1}".format(name, version)
     upload = "https://api.bintray.com/conan/{0}/public-conan".format(username)
 
-    builder = ConanMultiPackager(
-        username=username,
-        channel=channel,
-        reference=reference,
-        upload=upload,
-        remotes=upload,  # while redundant, this moves bincrafters remote to position 0
-        upload_only_when_stable=True,
-        stable_branch_pattern="stable/*")
+    build = os.getenv("BUILD", None)
+    if build:
+        build_env = os.getenv(build, None)
+        if build_env:
+            for env_var in build_env.split():
+                name, value = env_var.split("=", 1)
+                os.environ[name] = value
 
-    builder.add_common_builds(shared_option_name=name + ":shared")
+    builder = ConanMultiPackager(
+        username=os.getenv("CONAN_USERNAME", username),
+        channel=os.getenv("CONAN_CHANNEL", channel),
+        reference=os.getenv("CONAN_REFERENCE", reference),
+        upload=os.getenv("CONAN_UPLOAD", upload),
+        remotes=os.getenv("CONAN_REMOTES", upload))
+
+    builder.add_common_builds(shared_option_name="*:shared")
     builder.run()


### PR DESCRIPTION
The changes make it possible to override all the multi-packager variables from the usual conan env vars so that one can set up custom local one. For example to reroute building on CI to a personal account. It also adds parsing of a `BUILD` env var that contains space delimited env vars to apply during a build to allow for shorthand CI build variations. Finally, it uses "*:shared" for the shared option as packages might not have that option specifically and using the wildcard will allow building those without errors.