### PR TITLE
A couple of CI improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 build: false
 
+configuration:
+  - Debug
+  - Release
+  
 environment:
     PYTHON: "C:\\Python27"
     PYTHON_VERSION: "2.7.8"
@@ -13,6 +17,9 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
 
+matrix:
+  fast_finish: true
+  
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade

--- a/build.py
+++ b/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conan.packager import ConanMultiPackager
+from conan.packager import ConanMultiPackager, split_colon_env
 import os
 import re
 import platform
@@ -52,7 +52,24 @@ def get_env_vars():
 def get_os():
     return platform.system().replace("Darwin", "Macos")
 
-
+def get_build_types():
+    # Only Appveyor has CONFIGURATION, Travis uses both types anyway.
+    build_types_a = split_colon_env("CONFIGURATION") or ['Release', 'Debug']
+    build_types = split_colon_env("CONAN_BUILD_TYPES") or build_types_a
+    return build_types
+    
+def get_remotes():
+    user_remote = "https://api.bintray.com/conan/{0}/public-conan".format(username)
+    bincrafters_remote = 'https://api.bintray.com/conan/bincrafters/public-conan'
+    remotes = [ user_remote, bincrafters_remote ]
+    
+    # If the user supplied a remote manually we give him priority
+    # e.g. maybe he is trying to override user_remote or the bincrafters_remote repo.
+    remote_env = split_colon_env("CONAN_REMOTES")
+    if remote_env:
+        remotes = remote_env + remotes
+    return remotes
+    
 if __name__ == "__main__":
     name = get_name_from_recipe()
     username, channel, version = get_env_vars()
@@ -63,8 +80,9 @@ if __name__ == "__main__":
         username=username,
         channel=channel,
         reference=reference,
+        build_types=get_build_types(),
         upload=upload,
-        remotes=upload,  # while redundant, this moves bincrafters remote to position 0
+        remotes=get_remotes(),
         upload_only_when_stable=True,
         stable_branch_pattern="stable/*")
 


### PR DESCRIPTION
Enables easier split builds on appveyor.
Allows better control over remote repos for CI.
Appveyor immediately stops all builds if any of the jobs fails.