### PR TITLE
cmake_minimum_required should be put before project() call

### DIFF
--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Not crucial but it's a good style as per https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html