### PR TITLE
cmakelists : Remove cmake_binary_dir to fix build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(cmake_wrapper)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory("source_subfolder")


### PR DESCRIPTION
With the use of build_subfolder, the provided CMakeLists file doesn't find conanbuildinfo.cmake. It is located one level "higher", besides the CMakeLists file.