### PR TITLE
Add minimum cmake version on wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(cmake_wrapper)
 cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 project(cmake_wrapper)
+cmake_minimum_required(VERSION 2.8.11)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Hi!

Trying to solve future problems involving cmake toolchain file, I added `cmake_minimum_required`.

This suggestion came the from issue https://github.com/bincrafters/community/issues/212

Regards!