### PR TITLE
Disabled default 60 mins Azure Pipelines timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@ jobs:
 - job: Linux
   pool:
     vmImage: 'Ubuntu 16.04'
+  timeoutInMinutes: 0
   steps:
   - task: UsePythonVersion@0
     inputs:


### PR DESCRIPTION
With the disabled timeout, the [current actual timeout is 6 hours](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=vsts&tabs=yaml#timeouts).