### PR TITLE
Remove Xenial from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 linux: &linux
    os: linux
-   dist: xenial
    language: python
    python: "3.7"
    services:


### PR DESCRIPTION
@EricLemanissier reported about an error when building Conan Qt with Xenial as host. As xenial is beta, we could wait for stable release.

Related issue: https://github.com/conan-io/conan-docker-tools/issues/64