### PR TITLE
Add upstream template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
 ## Summary
 
-This repository contains "templates" for Git repositories hosting 3rdParty conan recipes and related files for setting up Continuous Integration services and Github. Please report questions or problems here: 
+This repository contains "templates" for Git repositories hosting 3rdParty conan recipes and related files for setting up Continuous Integration services and Github. Please report questions or problems here:
 
-https://github.com/bincrafters/community/issues/new  
+https://github.com/bincrafters/community/issues/new
 
 ## Using Templates
 
-The workflow is intended to be as simple as possible for users to setup a repository based on these templates.  The general steps are: 
+The workflow is intended to be as simple as possible for users to setup a repository based on these templates.  The general steps are:
 
-1. For a new Conan recipe, create an empty git repository 
-2.  Copy and paste the following folders into your repository root as-is, no changes are necessary: 
+1. For a new Conan recipe, create an empty git repository
+2.  Copy and paste the following folders into your repository root as-is, no changes are necessary:
 	1. .github
 	2. .ci
 3.  Copy and paste all the contents from ONE the template folders into your repository root:
-    1. default - Used for typical packages
-    2. header_only - Used for header-only packages
-    3. installer - Used for tools installers
-4.  Thoroughly review the following files, and edit any lines necessary: 
+    1. default - Used for typical packages (libraries) e.g. Boost
+    2. header_only - Used for header-only packages e.g. Catch2
+    3. installer - Used for tools installers e.g. cmake_installer
+	4. upstream - Used for in-source projects e.g. Google Flatbuffers
+4.  Thoroughly review the following files, and edit any lines necessary:
 	1. README.md - Find/Replace `package_name` with your actual package name (3 places)
 	2. conanfile.py - Virtually every line may need editing
-	
+
 ## Maintaining Templates
 
 These templates will always contain some duplicate content. When a change is required, the most thorough and efficient approach is to use a mechanism which lets you search/find/replace all instances of a particular piece of text in all files at one time.  Most graphical text editors have a feature for this, and command-line tools like `sed` are also capable of doing this.  However, the differences between the templates are often subtle and intentional, so most changes should be considered separately in the context of the template.  Use your best judgement to avoid mistakes.

--- a/upstream/.travis.yml
+++ b/upstream/.travis.yml
@@ -1,0 +1,121 @@
+sudo: required
+dist: xenial
+language: cpp
+
+env:
+  global:
+    # ---- TODO: Enter values ----
+    - CONAN_USERNAME="TODO_ENTER_PACKAGE_USERNAME"
+    - CONAN_PACKAGE_NAME="TODO_ENTER_PACKAGE_NAME"
+
+conan-buildsteps: &conan-buildsteps
+  before_install:
+    # use this step if you desire to manipulate CONAN variables programmatically
+    # dummy to overwrite default build steps
+    - true
+  install:
+    - chmod +x ./conan/ci/install.sh
+    - ./conan/ci/install.sh
+  script:
+    - chmod +x ./conan/ci/build.sh
+    - ./conan/ci/build.sh
+   # the following are dummies to overwrite default build steps
+  before_script:
+    - true
+  after_success:
+    - true
+  if: tag IS present
+conan-linux: &conan-linux
+  os: linux
+  sudo: required
+  language: python
+  python: "3.6"
+  services:
+    - docker
+  <<: *conan-buildsteps
+conan-osx: &conan-osx
+  os: osx
+  language: generic
+  <<: *conan-buildsteps
+
+matrix:
+  include:
+    # ---- TODO: PLACE HERE ALL EXISTING BUILD JOBS ----
+    #
+    # Conan testing and uploading
+    - compiler: gcc
+      env: CONAN=True
+      language: python
+      python: "3.6"
+      before_install:
+        - pip install -U pip
+      install:
+        - pip install conan
+      before_script:
+        - pip --version
+        - conan --version
+      script:
+        - CONAN_FULL_REFERENCE=${CONAN_PACKAGE_NAME}/master@${CONAN_USERNAME}/testing
+        - conan create . ${CONAN_FULL_REFERENCE} --build --test-folder "conan/test_package"
+      # ---- TODO: Include the following build step ONLY for a master version recipe upload and testing (no packages) ----
+      # ---- TODO: Remove after_success entirely if you don't want a master recipe version uploaded ----
+      after_success:
+        # If this build is NOT triggered by a pull request; AND got triggered by either a tag OR push to master
+        # and the following environment variables are set:
+        #   CONAN_UPLOAD - a reference to the Conan repository e.g. https://bintray.com/google/conan
+        #   CONAN_LOGIN_USERNAME - user for the upload e.g. upload_bot_username
+        #   CONAN_PASSWORD - password for the CONAN_LOGIN_USERNAME; for Bintray this is the API key
+        # then upload the new recipe version to the Conan repository.
+        #
+        # For the tag pushes we are using for the
+        #   version the tag name, removing the "v"
+        #   channel "stable"
+        # For master pushes we are using for the
+        #   version simply "master"
+        #   channel "testing"
+        - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" && -n "${CONAN_UPLOAD}" && -n "${CONAN_LOGIN_USERNAME}" && -n "${CONAN_PASSWORD}" ]]; then
+            conan remote add ${CONAN_PACKAGE_NAME} ${CONAN_UPLOAD} --insert;
+            conan remote list;
+
+            conan user -p "${CONAN_PASSWORD}" -r benchmark "${CONAN_LOGIN_USERNAME}";
+            conan upload --force -r ${CONAN_PACKAGE_NAME} --retry 3 --retry-wait 10 --confirm "${CONAN_FULL_REFERENCE}";
+          fi;
+      if: NOT tag IS present
+    # ---- TODO: If neccessary adjust the following configurations to your upstream project support -----
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
+    - <<: *conan-linux
+      env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
+    - <<: *conan-linux
+      env: CONAN_CLANG_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/clang7
+    - <<: *conan-osx
+      osx_image: xcode7.3
+      env: CONAN_APPLE_CLANG_VERSIONS=7.3
+    - <<: *conan-osx
+      osx_image: xcode8.3
+      env: CONAN_APPLE_CLANG_VERSIONS=8.1
+    - <<: *conan-osx
+      osx_image: xcode9
+      env: CONAN_APPLE_CLANG_VERSIONS=9.0
+    - <<: *conan-osx
+      osx_image: xcode9.4
+      env: CONAN_APPLE_CLANG_VERSIONS=9.1
+    - <<: *conan-osx
+      osx_image: xcode10
+      env: CONAN_APPLE_CLANG_VERSIONS=10.0
+
+# ---- TODO: Place here all existing default build steps ----

--- a/upstream/LICENSE.md
+++ b/upstream/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Bincrafters
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -1,0 +1,58 @@
+# Template for upstream in-source Conan recipes
+
+## Usage
+  1. Copy the `conan/` directory into the upstream project
+  2. Create a `conanfile.py` with the recipe, you can use [this template file](https://github.com/bincrafters/conan-templates/blob/master/conanfile.py)
+     * change the `source` method to:
+        ```     
+        def source(self):
+            # Wrap the original CMake file to call conan_basic_setup
+            shutil.move("CMakeLists.txt", "CMakeListsOriginal.txt")
+            shutil.move(os.path.join("conan", "CMakeLists.txt"), "CMakeLists.txt")
+        ```
+  3. Open the `.travis.yml`, search for `TODO` and follow the explanations
+  4. Open the `appyevor.yml`, search for `TODO` and follow the explanations
+  5. Save the adjusted `.travis.yml` and `appveyor.yml` files in the upstream project
+  6. Set the following environment variables in the Travis and AppVeyor UI (**don't forget encryption**):
+     * `CONAN_UPLOAD`: API URL to your Conan repository (most likely Bintray)
+     * `CONAN_LOGIN_USERNAME`: Your Conan repository username (e.g. Bintray username)
+     * `CONAN_PASSWORD` Your Conan repository password (e.g. Bintray API key)
+
+## Features
+  * generic files across different projects for easy maintainance and future updates
+  * easily configurable through environment variables
+  * builds and uploads packages on git tag pushes
+    * it uses the name of the git tag as version
+      * no manually version string maintaining required within the `conanfile.py`
+    * it removes the `v` from the git tag (if there is one)
+  * uploads the recipe-only as a master version on pushes to the master branch
+    * this can be easily removed
+  * tests on every non-tag and non-master push a single `conan create` build on every OS
+
+
+## Optional environment variables
+The following optional environment variables can change the behaviour of the builds.
+  * `CONAN_PACKAGE_VERSION`: E.g. `"1.0.0", "1.3.1"`. Default: Value of git tag. Gets used as the version number for the package.
+  * `CONAN_CHANNEL`: E.g. `"stable", "testing"` Default: `stable`. Gets used as the channel name for the package.
+  * `CONAN_DISABLE_SHARED_BUILD`: `"True", "False"`, Default: `False`. Disabled shared builds even when there is a shared option. Use this if shared builds are not supported on some configurations to prevent CI from failing.
+  * `CONAN_UPLOAD_ONLY_WHEN_STABLE`: `"True", "False"`, Default: `True`. Only upload builds which are considered as stable (= releases).
+  * `CONAN_STABLE_BRANCH_PATTERN`: Default: `r"v\d+\.\d+\.\d+.*"`. Pattern to let the build system know which builds are considered as stable.
+  * `CPT_TEST_FOLDER`: Default: `conan/test_package`. Path to a Conan test_package.
+  * `CONAN_HEADER_ONLY`: `"True", "False"`, Default: `False`.
+  * `CONAN_PURE_C`: `"True", "False"`, Default: `False`.
+
+## Issue tracker
+The issue tracker can be found here: https://github.com/bincrafters/community/issues
+
+
+## Stability
+### DO NOT INTRODUCE BREAKING BEHAVIOUR
+Only if it is absolutely neccessary or the benefits are extremely huge. If there are breaking changes **document them in this readme**. These templates are meant to be shared between very different projects with different setups and building environments and it's a terrible idea to start maintaining these files seperately for all of these projects.
+
+### Extending with new features
+Only introduce new features if they are actually used by some specific project which plans to or has already adopted Conan.
+
+
+## Known projects which are using a version of this template
+  * [google/flatbuffers](https://github.com/google/flatbuffers)
+  * [skypjack/uvw](https://github.com/skypjack/uvw)

--- a/upstream/appveyor.yml
+++ b/upstream/appveyor.yml
@@ -1,0 +1,68 @@
+image: Visual Studio 2017
+
+configuration:
+  - Debug
+  - Release
+
+environment:
+  global:
+    # ---- TODO: Enter values ----
+    CONAN_USERNAME: "TODO_ENTER_PACKAGE_USERNAME"
+    CONAN_PACKAGE_NAME: "TODO_ENTER_PACKAGE_NAME"
+  matrix:
+    # ---- TODO: PLACE HERE ALL EXISTING BUILD JOBS ----
+    #
+    # ---- TODO: If neccessary adjust the following configurations to your upstream project support -----
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 12
+      CONAN_BUILD_TYPES: Release
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 12
+      CONAN_BUILD_TYPES: Debug
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 14
+      CONAN_BUILD_TYPES: Release
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CONAN_VISUAL_VERSIONS: 14
+      CONAN_BUILD_TYPES: Debug
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+      CONAN_BUILD_TYPES: Release
+      CONAN: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CONAN_VISUAL_VERSIONS: 15
+      CONAN_BUILD_TYPES: Debug
+      CONAN: true
+
+matrix:
+  exclude:
+    # We only need one time all Conan jobs, so exclude all but one configuration from matrix expanding
+    # ---- TODO: If more configuration matrix values exist, extend this until only one value remains ----
+    # ---- TODO: If no configuration matrix value exist, add one ----
+    - CONAN: true
+      configuration: Debug
+  fast_finish: true
+
+for:
+-
+  matrix:
+    except:
+      - CONAN: true
+
+# ---- TODO: Place here all existing default build steps ----
+
+-
+  matrix:
+    only:
+      - CONAN: true
+  skip_non_tags: true
+
+  install:
+    - python conan/appveyor/install.py
+
+  build_script:
+    - python conan/appveyor/build.py

--- a/upstream/conan/CMakeLists.txt
+++ b/upstream/conan/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+include(${CMAKE_SOURCE_DIR}/CMakeListsOriginal.txt)

--- a/upstream/conan/appveyor/build.py
+++ b/upstream/conan/appveyor/build.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+if os.getenv("APPVEYOR_REPO_TAG") != "true":
+    print("Skip build step. It's not TAG")
+else:
+    os.system("python conan/build.py")

--- a/upstream/conan/appveyor/install.py
+++ b/upstream/conan/appveyor/install.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+if os.getenv("APPVEYOR_REPO_TAG") != "true":
+    print("Skip step. It's not TAG")
+else:
+    os.system("pip install conan conan-package-tools")

--- a/upstream/conan/build.py
+++ b/upstream/conan/build.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from cpt.packager import ConanMultiPackager
+import os
+
+def set_appveyor_environment():
+    if os.getenv("APPVEYOR") is not None:
+        os.environ["CONAN_STABLE_BRANCH_PATTERN"] = os.getenv("CONAN_STABLE_BRANCH_PATTERN", "master")
+        os.environ["CONAN_ARCHS"] = os.getenv("CONAN_ARCHS", "x86,x86_64")
+        os.environ["CONAN_BUILD_TYPES"] = os.getenv("CONAN_BUILD_TYPES", "Release,Debug").replace('"', '')
+        os.environ["CONAN_PACKAGE_VERSION"] = os.getenv("CONAN_PACKAGE_VERSION", os.getenv("APPVEYOR_REPO_TAG_NAME"))
+
+if __name__ == "__main__":
+    set_appveyor_environment()
+    login_username = os.getenv("CONAN_LOGIN_USERNAME")
+    username = os.getenv("CONAN_USERNAME")
+    tag_version = os.getenv("CONAN_PACKAGE_VERSION", os.getenv("TRAVIS_TAG"))
+    package_version = tag_version.replace("v", "")
+    package_name_unset = "SET-CONAN_PACKAGE_NAME-OR-CONAN_REFERENCE"
+    package_name = os.getenv("CONAN_PACKAGE_NAME", package_name_unset)
+    reference = "{}/{}".format(package_name, package_version)
+    channel = os.getenv("CONAN_CHANNEL", "stable")
+    upload = os.getenv("CONAN_UPLOAD")
+    stable_branch_pattern = os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"v\d+\.\d+\.\d+.*")
+    test_folder = os.getenv("CPT_TEST_FOLDER", os.path.join("conan", "test_package"))
+    upload_only_when_stable = os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", True)
+    header_only = os.getenv("CONAN_HEADER_ONLY", False)
+    pure_c = os.getenv("CONAN_PURE_C", False)
+
+    disable_shared = os.getenv("CONAN_DISABLE_SHARED_BUILD", "False")
+    if disable_shared == "True" and package_name == package_name_unset:
+        raise Exception("CONAN_DISABLE_SHARED_BUILD: True is only supported when you define CONAN_PACKAGE_NAME")
+
+    builder = ConanMultiPackager(username=username,
+                                 reference=reference,
+                                 channel=channel,
+                                 login_username=login_username,
+                                 upload=upload,
+                                 stable_branch_pattern=stable_branch_pattern,
+                                 upload_only_when_stable=upload_only_when_stable,
+                                 test_folder=test_folder)
+    if header_only == "False":
+        builder.add_common_builds(pure_c=pure_c)
+    else:
+        builder.add()
+
+    filtered_builds = []
+    for settings, options, env_vars, build_requires, reference in builder.items:
+        if disable_shared == "False" or not options["{}:shared".format(package_name)]:
+             filtered_builds.append([settings, options, env_vars, build_requires])
+    builder.builds = filtered_builds
+
+    builder.run()

--- a/upstream/conan/ci/build.sh
+++ b/upstream/conan/ci/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+conan user
+python conan/build.py

--- a/upstream/conan/ci/install.sh
+++ b/upstream/conan/ci/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 2.7.15
+    pyenv virtualenv 2.7.15 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install -U conan_package_tools conan

--- a/upstream/conan/test_package/CMakeLists.txt
+++ b/upstream/conan/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(test_package)
+cmake_minimum_required(VERSION 2.8.11)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/upstream/conan/test_package/conanfile.py
+++ b/upstream/conan/test_package/conanfile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+
+from conans import ConanFile, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/upstream/conan/test_package/test_package.cpp
+++ b/upstream/conan/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <iostream>
+
+int main()
+{
+    std::cout << "Bincrafters\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Hi!

This PR was created to move [conan-templates-upstream](https://github.com/bincrafters/conan-templates-upstream) into conan-templates.

Upstream is the development flow in-source, when we support both project and recipe together e.g. taocpp, Flatbuffers, Catch2 ...