### PR TITLE
- change environment variable name PYTHON -> PYTHON_HOME

### DIFF
--- a/default/appveyor.yml
+++ b/default/appveyor.yml
@@ -1,7 +1,7 @@
 build: false
 
 environment:
-    PYTHON: "C:\\Python37"
+    PYTHON_HOME: "C:\\Python37"
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -12,7 +12,7 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
 
 install:
-  - set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools bincrafters_package_tools
   - conan user # It creates the conan data directory

--- a/header_only/appveyor.yml
+++ b/header_only/appveyor.yml
@@ -1,14 +1,14 @@
 build: false
 
 environment:
-    PYTHON: "C:\\Python37"
+    PYTHON_HOME: "C:\\Python37"
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
 
 install:
-  - set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools bincrafters_package_tools
   - conan user # It creates the conan data directory

--- a/installer/appveyor.yml
+++ b/installer/appveyor.yml
@@ -1,7 +1,7 @@
 build: false
 
 environment:
-    PYTHON: "C:\\Python37"
+    PYTHON_HOME: "C:\\Python37"
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -12,7 +12,7 @@ environment:
           ARCH: x86_64
 
 install:
-  - set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools bincrafters_package_tools
   - conan user # It creates the conan data directory


### PR DESCRIPTION
environment variable `PYTHON` is used by autotools (as documented [here](http://www.gnu.org/software/automake/manual/html_node/Python.html)), and it must point to the valid python interpreter (in our case it's just python directory)
if we use `PYTHON`, autotools-based projects may fail with the following [error](https://ci.appveyor.com/project/BinCrafters/conan-pkg-config-installer/builds/22260187/job/bmkkwxk1m7dl6b0u):
```
pkg-config_installer/0.29.2@bincrafters/testing: checking whether C:\Python37 version is >= 2.5... no
pkg-config_installer/0.29.2@bincrafters/testing: configure: error: Python interpreter is too old
pkg-config_installer/0.29.2@bincrafters/testing: configure: error: ./configure failed for glib
pkg-config_installer/0.29.2@bincrafters/testing: 
pkg-config_installer/0.29.2@bincrafters/testing: ERROR: Package 'b2fcbc60b3bee75023a4f7934cadb723eec550bd' build failed

```