### PR TITLE
macOS: Remove XCode 7.3 / macOS 10.11

### DIFF
--- a/default/.travis.yml
+++ b/default/.travis.yml
@@ -31,9 +31,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
       - <<: *osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3
-      - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1
       - <<: *osx


### PR DESCRIPTION
macOS 10.11 is end-of-life, we shouldn't add build jobs for this version to new packages.

For now, I wouldn't go so far and start to actively remove this version from existing packages, but we shouldn't add it anymore to new ones.