### PR TITLE
Remove encoding header

### DIFF
--- a/default/conanfile.py
+++ b/default/conanfile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 

--- a/default/test_package/conanfile.py
+++ b/default/test_package/conanfile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 

--- a/header_only/conanfile.py
+++ b/header_only/conanfile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, tools
 import os
 

--- a/header_only/test_package/conanfile.py
+++ b/header_only/test_package/conanfile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 

--- a/installer_only/conanfile.py
+++ b/installer_only/conanfile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 

--- a/installer_only/test_package/conanfile.py
+++ b/installer_only/test_package/conanfile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, tools
 import os
 


### PR DESCRIPTION
Python 3 is Unicode via default

Let's remove the encoding header for (new) recipes as talked about in https://github.com/bincrafters/bincrafters-conventions/pull/13